### PR TITLE
Shrink image

### DIFF
--- a/docker/ems/base/tibco-ems/Dockerfile
+++ b/docker/ems/base/tibco-ems/Dockerfile
@@ -1,27 +1,36 @@
 FROM tutum/centos
-COPY files/TIB_ems_8.2.1_linux_x86.zip /tmp/
-COPY files/jdk-7u75-linux-x64.rpm /tmp/
+
+# Dont forget to ./warehouse.py /dir/to/installers
+ENV warehouse_host http://localhost:18000
 
 RUN useradd -ms /bin/bash tibco
 ENV HOME /home/node
-RUN rpm -Uvh /tmp/jdk-7u75-linux-x64.rpm
-RUN alternatives --install /usr/bin/java java /usr/java/latest/bin/java 2
-RUN yum -y  install unzip
 
+RUN yum -y install unzip wget
 
-RUN mkdir /tmp/software/
-RUN mv /tmp/TIB_ems_8.2.1_linux_x86.zip /tmp/software/
+RUN mkdir -p /tmp/software && \
+    cd /tmp/software && \
+    wget --quiet $warehouse_host/jdk-7u79-linux-x64.rpm && \
+    rpm -Uvh jdk-7u79-linux-x64.rpm && \
+    alternatives --install /usr/bin/java java /usr/java/latest/bin/java 2 && \
 
-RUN unzip /tmp/software/TIB_ems_8.2.1_linux_x86.zip -d /tmp/software/
-RUN /tmp/software/TIBCOUniversalInstaller-lnx-x86.bin -silent
+RUN mkdir -p /tmp/software && \
+    cd /tmp/software && \
+    wget --quiet $warehouse_host/TIB_ems_8.2.1_linux_x86.zip && \
+    unzip TIB_ems_8.2.1_linux_x86.zip -d ems && \
+    cd ems && \
+    ./TIBCOUniversalInstaller-lnx-x86.bin -silent && \
+    cd / && \
+    rm -rf /tmp/software
 
 EXPOSE 7222
 
 COPY files/ems.sh /opt/tibco/ems/
-RUN chmod +x /opt/tibco/ems/ems.sh
-RUN chown -R tibco:tibco /tmp/software/
-RUN chown -R tibco:tibco /opt/tibco/
-RUN chown -R tibco:tibco /home/user/tibco/
+
+RUN chmod +x /opt/tibco/ems/ems.sh && \
+    chown -R tibco:tibco /tmp/software/ && \
+    chown -R tibco:tibco /opt/tibco/ && \
+    chown -R tibco:tibco /home/user/tibco/
 
 VOLUME /home/user/tibco/tibco/cfgmgmt/ems/data:rw
 

--- a/docker/ems/base/tibco-ems/Dockerfile
+++ b/docker/ems/base/tibco-ems/Dockerfile
@@ -1,7 +1,8 @@
 FROM tutum/centos
 
 # Dont forget to ./warehouse.py /dir/to/installers
-ENV warehouse_host http://localhost:18000
+# 172.17.0.1 is my host address.  I don't know of a nice way of autodetecting this :(
+ENV warehouse_host http://172.17.0.1:18000
 
 RUN useradd -ms /bin/bash tibco
 ENV HOME /home/node
@@ -12,7 +13,7 @@ RUN mkdir -p /tmp/software && \
     cd /tmp/software && \
     wget --quiet $warehouse_host/jdk-7u79-linux-x64.rpm && \
     rpm -Uvh jdk-7u79-linux-x64.rpm && \
-    alternatives --install /usr/bin/java java /usr/java/latest/bin/java 2 && \
+    rm -rf /tmp/software
 
 RUN mkdir -p /tmp/software && \
     cd /tmp/software && \
@@ -28,7 +29,6 @@ EXPOSE 7222
 COPY files/ems.sh /opt/tibco/ems/
 
 RUN chmod +x /opt/tibco/ems/ems.sh && \
-    chown -R tibco:tibco /tmp/software/ && \
     chown -R tibco:tibco /opt/tibco/ && \
     chown -R tibco:tibco /home/user/tibco/
 
@@ -36,4 +36,3 @@ VOLUME /home/user/tibco/tibco/cfgmgmt/ems/data:rw
 
 USER tibco
 CMD /opt/tibco/ems/ems.sh
-##CMD /run.sh

--- a/docker/ems/base/tibco-ems/warehouse.py
+++ b/docker/ems/base/tibco-ems/warehouse.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import http.server
+import os
+import socketserver
+import sys
+
+PORT = 18000
+
+
+def run():
+    handler = http.server.SimpleHTTPRequestHandler
+    httpd = socketserver.TCPServer(("", PORT), handler)
+
+    print("serving at port", PORT)
+    httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    # First argument is the directory to serve files from
+    os.chdir(sys.argv[1])
+    run()


### PR DESCRIPTION
Thanks for a great start to EMS.  The problem with your Dockerfile is that each command of `RUN` `COPY` etc creates a new layer in the image.  When you're running the container, you don't need the installer files hanging around.

I have reworked the Dockerfile so that it first installs wget into the container, then in one command, download Java, install and clean up.  A similar `RUN` command exists for EMS.

I've also included warehouse.py which is a VERY simple web server that let's you put your big installer files outside of the git repo.  I run

``` shell
./warehouse.py ~/tibcoinst
```

The warehouse host is http://dockerhost:18000.  Currently I don't know how to inject an environment variable into the build process so I've had to hard code the IP address that my docker host has.  Not ideal, but I can't figure out a better way for now.

I hope this helps
